### PR TITLE
autodns: remove TXT RRs when validation fails

### DIFF
--- a/roles/acme/tasks/challenge/dns-01/autodns.yml
+++ b/roles/acme/tasks/challenge/dns-01/autodns.yml
@@ -60,7 +60,6 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ challenge }}"
 
-
   always:
     - name: remove created SAN TXT records to keep DNS zone clean
       ansible.builtin.uri:

--- a/roles/acme/tasks/challenge/dns-01/autodns.yml
+++ b/roles/acme/tasks/challenge/dns-01/autodns.yml
@@ -60,6 +60,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ challenge }}"
 
+
+  always:
     - name: remove created SAN TXT records to keep DNS zone clean
       ansible.builtin.uri:
         url: "https://api.autodns.com/v1/zone/{{ acme_domain.zone }}/a.ns14.net"


### PR DESCRIPTION
If the validation or the certificate download fails for whatever reason the TXT record for the domain wasn't removed but stayed in the Zone.

The record removal step should be executed irrespective of the result of the validation step