### PR TITLE
Fix wrong module name in roles/acme/tasks/challenge/http-01/s3.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,6 +22,7 @@ tags:
 dependencies:
   community.crypto: '>=1.0.0'
   openstack.cloud: '>=1.2.1'
+  amazon.aws: '>=5.0.0'
 repository: 'https://github.com/T-Systems-MMS/ansible-collection-acme'
 documentation: 'https://github.com/T-Systems-MMS/ansible-collection-acme'
 homepage: 'https://github.com/T-Systems-MMS/ansible-collection-acme'

--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -55,7 +55,7 @@
         data: "{{ challenge }}"
 
     - name: Remove challenge file for SAN domain from s3 bucket
-      amazon.aws.aws_s3_object:
+      amazon.aws.s3_object:
         aws_access_key: "{{ acme_s3_access_key }}"
         aws_secret_key: "{{ acme_s3_secret_key }}"
         bucket: "{{ acme_s3_bucket_name }}"


### PR DESCRIPTION
The wrong Module name amazon.aws.aws_s3_object crashs our certificate pipelines.

Fixed: 
- nodule name amazon.aws.aws_s3_object -> amazon.aws.s3_object
- added collection amazon.aws as dependency in galaxy.yml

