### PR TITLE
[Bug] Handle half validated requests with multiple domains

### DIFF
--- a/plugins/filter/find_challenges.py
+++ b/plugins/filter/find_challenges.py
@@ -29,6 +29,7 @@ def find_challenges(challenge_response: dict, challenge_type: str, expected_doma
 
     return dict()
 
+
 def find_domains_in_response(challenge_response: dict, challenge_type: str) -> set:
     """
     find the domains in the response for which the API responded with a challenge of the specified challenge_type
@@ -44,6 +45,7 @@ def find_domains_in_response(challenge_response: dict, challenge_type: str) -> s
                 domains.add(domain)
 
     return domains
+
 
 def build_challenges(challenge_response: dict, challenge_type: str, expected_domains: list) -> dict:
     """

--- a/tests/integration/targets/acme_letsencrypt/find-challenge-filter-plugin.yml
+++ b/tests/integration/targets/acme_letsencrypt/find-challenge-filter-plugin.yml
@@ -264,4 +264,3 @@
               - "'blahtest1.example.org' in test_challenge and 'blahtest2.example.org' in test_challenge"
               - "data_with_mixed_challenge_data['authorizations']['blahtest1.example.org']['challenges'][1]['token'] in test_challenge['blahtest1.example.org']['http-01'].resource_value"
               - "data_with_mixed_challenge_data['challenge_data']['blahtest2.example.org']['http-01'].resource_value in test_challenge['blahtest2.example.org']['http-01'].resource_value"
-


### PR DESCRIPTION
On certificates with multiple subject names (subject_alt_name), there is the possibility that a validation goes halfway through.

In such a case the filter_challenges filter plugin failed because it only searched in the authorizations field  when challenge_data field was empty. In a half-way validation the challenge_data will carry the tokens of the pending validations and therefore the find_challenges() fails on a expected_not_found validation.

I have attached a sample response in TEST-08