### PR TITLE
add retry to all certificate download tasks in challenge modules

### DIFF
--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -24,6 +24,8 @@ acme_private_key_type: "ECC"
 acme_private_key_curve: "secp384r1"
 acme_remaining_days: "30"
 acme_challenge_timeout: 3600
+acme_certificate_validation_retries: 3
+acme_certificate_validation_delay: 30
 
 ### provider specific config
 acme_s3_config_region: eu-west-1

--- a/roles/acme/tasks/challenge/dns-01/autodns.yml
+++ b/roles/acme/tasks/challenge/dns-01/autodns.yml
@@ -57,8 +57,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
   always:

--- a/roles/acme/tasks/challenge/dns-01/autodns.yml
+++ b/roles/acme/tasks/challenge/dns-01/autodns.yml
@@ -56,6 +56,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
   always:
     - name: Remove created SAN TXT records to keep DNS zone clean

--- a/roles/acme/tasks/challenge/dns-01/azure.yml
+++ b/roles/acme/tasks/challenge/dns-01/azure.yml
@@ -49,6 +49,10 @@
     terms_agreed: true
     remaining_days: "{{ acme_remaining_days }}"
     data: "{{ acme_challenge }}"
+  register: acme_certificate_validation
+  retries: 10
+  delay: 30
+  until: acme_certificate_validation is not failed
 
 - name: Remove created SAN top-level TXT records to keep DNS zone clean
   azure.azcollection.azure_rm_dnsrecordset:

--- a/roles/acme/tasks/challenge/dns-01/azure.yml
+++ b/roles/acme/tasks/challenge/dns-01/azure.yml
@@ -50,8 +50,8 @@
     remaining_days: "{{ acme_remaining_days }}"
     data: "{{ acme_challenge }}"
   register: acme_certificate_validation
-  retries: 10
-  delay: 30
+  retries: "{{ acme_certificate_validation_retries }}"
+  delay: "{{ acme_certificate_validation_delay }}"
   until: acme_certificate_validation is not failed
 
 - name: Remove created SAN top-level TXT records to keep DNS zone clean

--- a/roles/acme/tasks/challenge/dns-01/domain-offensive.yml
+++ b/roles/acme/tasks/challenge/dns-01/domain-offensive.yml
@@ -36,8 +36,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
   always:

--- a/roles/acme/tasks/challenge/dns-01/domain-offensive.yml
+++ b/roles/acme/tasks/challenge/dns-01/domain-offensive.yml
@@ -35,6 +35,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
   always:
     - name: Remove created SAN TXT records to keep DNS zone clean

--- a/roles/acme/tasks/challenge/dns-01/hetzner.yml
+++ b/roles/acme/tasks/challenge/dns-01/hetzner.yml
@@ -53,6 +53,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
     - name: Remove created SAN TXT records to keep DNS zone clean
       ansible.builtin.uri:

--- a/roles/acme/tasks/challenge/dns-01/hetzner.yml
+++ b/roles/acme/tasks/challenge/dns-01/hetzner.yml
@@ -54,8 +54,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
     - name: Remove created SAN TXT records to keep DNS zone clean

--- a/roles/acme/tasks/challenge/dns-01/nsupdate.yml
+++ b/roles/acme/tasks/challenge/dns-01/nsupdate.yml
@@ -46,8 +46,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
       when:
         - acme_certificate_enabled is not defined or acme_certificate_enabled | bool

--- a/roles/acme/tasks/challenge/dns-01/nsupdate.yml
+++ b/roles/acme/tasks/challenge/dns-01/nsupdate.yml
@@ -45,6 +45,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
       when:
         - acme_certificate_enabled is not defined or acme_certificate_enabled | bool
 

--- a/roles/acme/tasks/challenge/dns-01/openstack.yml
+++ b/roles/acme/tasks/challenge/dns-01/openstack.yml
@@ -35,8 +35,8 @@
     remaining_days: "{{ acme_remaining_days }}"
     data: "{{ acme_challenge }}"
   register: acme_certificate_validation
-  retries: 10
-  delay: 30
+  retries: "{{ acme_certificate_validation_retries }}"
+  delay: "{{ acme_certificate_validation_delay }}"
   until: acme_certificate_validation is not failed
 
 - name: Remove TXT records from DNS zone

--- a/roles/acme/tasks/challenge/dns-01/openstack.yml
+++ b/roles/acme/tasks/challenge/dns-01/openstack.yml
@@ -34,6 +34,10 @@
     terms_agreed: true
     remaining_days: "{{ acme_remaining_days }}"
     data: "{{ acme_challenge }}"
+  register: acme_certificate_validation
+  retries: 10
+  delay: 30
+  until: acme_certificate_validation is not failed
 
 - name: Remove TXT records from DNS zone
   openstack.cloud.recordset:

--- a/roles/acme/tasks/challenge/dns-01/pebble.yml
+++ b/roles/acme/tasks/challenge/dns-01/pebble.yml
@@ -40,6 +40,6 @@
         data: "{{ acme_challenge }}"
         validate_certs: "{{ acme_validate_certs | default(true) }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed

--- a/roles/acme/tasks/challenge/dns-01/pebble.yml
+++ b/roles/acme/tasks/challenge/dns-01/pebble.yml
@@ -39,3 +39,7 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
         validate_certs: "{{ acme_validate_certs | default(true) }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed

--- a/roles/acme/tasks/challenge/http-01/azbs.yml
+++ b/roles/acme/tasks/challenge/http-01/azbs.yml
@@ -49,8 +49,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
     - name: Remove challenge file for SAN domain from azure blob storage container

--- a/roles/acme/tasks/challenge/http-01/azbs.yml
+++ b/roles/acme/tasks/challenge/http-01/azbs.yml
@@ -48,6 +48,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
     - name: Remove challenge file for SAN domain from azure blob storage container
       azure.azcollection.azure_rm_storageblob:

--- a/roles/acme/tasks/challenge/http-01/local.yml
+++ b/roles/acme/tasks/challenge/http-01/local.yml
@@ -40,6 +40,10 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
         validate_certs: "{{ acme_validate_certs | default(true) }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
     - name: Remove challenge/hash files for SAN domains from fs
       ansible.builtin.file:

--- a/roles/acme/tasks/challenge/http-01/local.yml
+++ b/roles/acme/tasks/challenge/http-01/local.yml
@@ -41,8 +41,8 @@
         data: "{{ acme_challenge }}"
         validate_certs: "{{ acme_validate_certs | default(true) }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
     - name: Remove challenge/hash files for SAN domains from fs

--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -57,8 +57,8 @@
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
-      retries: 10
-      delay: 30
+      retries: "{{ acme_certificate_validation_retries }}"
+      delay: "{{ acme_certificate_validation_delay }}"
       until: acme_certificate_validation is not failed
 
     - name: Remove challenge file for SAN domain from s3 bucket

--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -56,6 +56,10 @@
         terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
+      register: acme_certificate_validation
+      retries: 10
+      delay: 30
+      until: acme_certificate_validation is not failed
 
     - name: Remove challenge file for SAN domain from s3 bucket
       amazon.aws.s3_object:


### PR DESCRIPTION
sometimes we were experiencing some network timeouts here which failed the whole playbook and needed to be fixed by manual playbook retry.

lets hope the retries every 30s for up to 5min cover our intermediate connection issues here