### PR TITLE
Migrate hetzner dns-01 provider to community.dns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# The default root path for Ansible config files on the controller
+.ansible/
+
+# Retry files generated for failed Ansible playbook runs
+*.retry
+
+# Python stuff
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -23,6 +23,7 @@ dependencies:
   amazon.aws: ">=5.0.0"
   azure.azcollection: ">=1.14.0"
   community.general: ">10.3.0"
+  community.dns: ">=4.1.0"
 repository: https://github.com/telekom-mms/ansible-collection-acme
 documentation: https://github.com/telekom-mms/ansible-collection-acme
 homepage: https://github.com/telekom-mms/ansible-collection-acme

--- a/roles/acme/tasks/challenge/dns-01/hetzner.yml
+++ b/roles/acme/tasks/challenge/dns-01/hetzner.yml
@@ -3,31 +3,18 @@
 - name: Validate challenge only if it is created or changed # noqa no-handler
   when: acme_challenge is changed
   block:
-    - name: Lookup the zone_id using the acme_domain.zone
-      ansible.builtin.uri:
-        url: https://dns.hetzner.com/api/v1/zones?name={{ acme_domain.zone }}
-        headers:
-          Auth-API-Token: "{{ acme_hetzner_auth_token }}"
-      register: acme_lookup_zone_id
-
     - name: Add a new TXT record to the SAN domains
-      ansible.builtin.uri:
-        url: https://dns.hetzner.com/api/v1/records
-        method: POST
-        body_format: json
-        body:
-          {
-            "name": "{{ '_acme-challenge' }}{{ '' if item | replace('*.', '') == (item.split('.')[-2:] | join('.')) else '.' }}\
-                     {{ (item | replace('*.', '')).split('.')[:-2] | join('.') }}",
-            "ttl": 60,
-            "type": "TXT",
-            "value": "{{ acme_challenge_data[item]['dns-01']['resource_value'] }}",
-            "zone_id": "{{ acme_lookup_zone_id.json.zones[0].id }}",
-          }
-        headers:
-          Auth-API-Token: "{{ acme_hetzner_auth_token }}"
+      community.dns.hetzner_dns_record:
+        state: present
+        zone: "{{ acme_domain.zone }}"
+        # if wildcard, prefix is '' else simply the zone subdomain
+        prefix: "{{ '_acme-challenge' }}{{ '' if item | replace('*.', '') == (item.split('.')[-2:] | join('.')) else '.' ~ (item | replace('*.', '')).split('.')[:-2] | join('.') }}"
+        ttl: 60
+        type: TXT
+        value: "{{ acme_challenge_data[item]['dns-01']['resource_value'] }}"
+        hetzner_api_token: "{{ acme_hetzner_auth_token }}"
       loop: "{{ acme_domain.subject_alt_name }}"
-      register: acme_records
+      register: acme_record_info
       when:
         - acme_domain.subject_alt_name is defined
         # only runs if the challenge is run the first time, because then there is challenge_data
@@ -41,7 +28,7 @@
       timeout: "{{ acme_challenge_timeout }}"
       community.crypto.acme_certificate:
         account_key_src: "{{ acme_account_key_path }}"
-        account_email: "{{ acme_account_email }}"
+        modify_account: false
         csr: "{{ acme_csr_path }}"
         cert: "{{ acme_cert_path }}"
         fullchain: "{{ acme_fullchain_path }}"
@@ -50,7 +37,6 @@
         force: "{{ acme_force_renewal | default(false) }}"
         acme_directory: "{{ acme_directory }}"
         acme_version: 2
-        terms_agreed: true
         remaining_days: "{{ acme_remaining_days }}"
         data: "{{ acme_challenge }}"
       register: acme_certificate_validation
@@ -59,12 +45,15 @@
       until: acme_certificate_validation is not failed
 
     - name: Remove created SAN TXT records to keep DNS zone clean
-      ansible.builtin.uri:
-        url: https://dns.hetzner.com/api/v1/records/{{ item }}
-        method: DELETE
-        headers:
-          Auth-API-Token: "{{ acme_hetzner_auth_token }}"
-      loop: "{{ acme_records | json_query('results[*].json.record.id') }}"
+      community.dns.hetzner_dns_record:
+        state: absent
+        zone_id: "{{ item.zone_id }}"
+        # if wildcard, prefix is '' else simply the zone subdomain
+        prefix: "{{ '_acme-challenge' }}{{ '' if item.item | replace('*.', '') == (item.item.split('.')[-2:] | join('.')) else '.' ~ (item.item | replace('*.', '')).split('.')[:-2] | join('.') }}"
+        type: TXT
+        value: "{{ acme_challenge_data[item.item]['dns-01']['resource_value'] }}"
+        hetzner_api_token: "{{ acme_hetzner_auth_token }}"
+      loop: "{{ acme_record_info.results }}"
       when:
         - acme_domain.subject_alt_name is defined
         # only runs if the challenge is run the first time, because then there is challenge_data

--- a/roles/acme/tasks/create-challenge.yml
+++ b/roles/acme/tasks/create-challenge.yml
@@ -4,17 +4,27 @@
     # e.g. acme_provider_path is "challenge/http-01/s3.yml" > dirname is "challenge/http-01" > basename is "http-01"
     challenge_type: "{{ acme_provider_path | dirname | basename }}"
   block:
-    - name: Create a challenge using a account key file for {{ acme_domain.certificate_name }}
+    - name: Ensure ACME account is registered
+      community.crypto.acme_account:
+        account_key_src: "{{ acme_account_key_path }}"
+        state: present
+        acme_directory: "{{ acme_directory }}"
+        acme_version: 2
+        contact:
+          - "mailto:{{ acme_account_email }}"
+        terms_agreed: true
+      register: acme_account_info
+
+    - name: Create a challenge using an account key file for {{ acme_domain.certificate_name }}
       community.crypto.acme_certificate:
         account_key_src: "{{ acme_account_key_path }}"
-        account_email: "{{ acme_account_email }}"
         csr: "{{ acme_csr_path }}"
         cert: "{{ acme_cert_path }}"
         challenge: "{{ challenge_type }}"
         force: "{{ acme_force_renewal | default(false) }}"
         acme_directory: "{{ acme_directory }}"
         acme_version: 2
-        terms_agreed: true
+        modify_account: false
         remaining_days: "{{ acme_remaining_days }}"
         validate_certs: "{{ acme_validate_certs | default(true) }}"
       register: acme_challenge

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-hetzner.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-hetzner.yml
@@ -27,6 +27,7 @@
     - name: Check if the certificate has correct data
       ansible.builtin.assert:
         that:
-          - result.subject.commonName == "{{ acme_domain.certificate_name }}"
-          - "'DNS:{{ acme_domain.certificate_name }}' in result.subject_alt_name"
-          - "'(STAGING) Artificial Apricot R3' in result.issuer.commonName"
+          - result.subject.commonName == acme_domain.certificate_name
+          - "'DNS:' ~ acme_domain.certificate_name in result.subject_alt_name"
+          # NOTE: due to changing issuers, the only commonality is the string '(STAGING)'.
+          - "'(STAGING)' in result.issuer.commonName"


### PR DESCRIPTION
### Summary
-  Migrates the underlying DNS challenge interaction logic from deprecated dns.hetzner.com api over to community.dns collection(#62)
- Cleans up deprecation warnings tied to the legacy acme_certificate fields by adding a new task for acme_account checks
- Updates integration/unit tests to match the new acme issuers [Let's Encrypt Staging Environment](https\://letsencrypt.org/docs/staging-environment/)
- Tested successfully with a wildcard domain and a custom DNS zone.